### PR TITLE
Readme update and test mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example:
     func handler(w http.ResponseWriter, r *http.Request) {
         defer func() {
             if iface := recover(); iface != nil {
-                Notifier.Panic(iface, r, nil)
+                Notifier.NotifyPanic(iface, r, nil)
             }
         }()
 
@@ -82,7 +82,7 @@ Appengine
         if v, ok := n.N.Transport().(*gobrake.JSONTransport); ok {
             v.Client = urlfetch.Client(c)
         }
-        if err := n.N.Panic(e, r, session); err != nil {
+        if err := n.N.NotifyPanic(e, r, session); err != nil {
             c.Errorf("Notify failed: %v", err)
         }
     }
@@ -95,7 +95,7 @@ Appengine
         defer func() {
             if iface := recover(); iface != nil {
                 c := appengine.NewContext(r)
-                Notifier.Panic(c, iface, r, nil)
+                Notifier.NotifyPanic(c, iface, r, nil)
                 panic(iface)
             }
         }()


### PR DESCRIPTION
Hello Airbrake friends! 

Good News, we love Airbrake. We also love Go, we found this spiffy library earlier today, and happened across a couple small things we thought we could help out with. 

First:
We've updated the readme references to "Notifier.Panic" to "Notifier.PanicNotify" as it looks like there is no Panic function, and there is a PanicNotify that seems to do what we would expect. (Looks like this happened in the "Tweaks." commit, the last one on the log.)

Second:
We also noticed in doing this update that tests were expecting a local service to receive calls that would normally go to airbrake. So, we used net/http/httptest to setup a little fake server to receive and respond to those requests instead. (So peeps not working at airbrake can have passing tests too!) 

Thanks for a great tool and a Go library to implement it!
