### PR TITLE
Remove deps

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -7,21 +7,24 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
 	"time"
-
-	"github.com/mreiferson/go-httpclient"
 )
 
 var (
-	transport = &httpclient.Transport{
-		ConnectTimeout:        1 * time.Second,
-		ResponseHeaderTimeout: 5 * time.Second,
-		RequestTimeout:        10 * time.Second,
+	client = &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			Dial: func(netw, addr string) (net.Conn, error) {
+				return net.DialTimeout(netw, addr, 3*time.Second)
+			},
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+		Timeout: 10 * time.Second,
 	}
-	client = &http.Client{Transport: transport}
 )
 
 type Notifier struct {


### PR DESCRIPTION
Remove the dependency.

The most important would be the glog removal. It declares tons of flags so it pollutes the `-help` when we import `gobrake`. It also uses `-v` so any `gobrake` caller can't declare its own `-v`.

I also removed the `go-httpclient` because it seemed a bit overkill to import a full package for couple of lines.

It also have the advantage to make `gobrake` "standalone" and not pollute the `Godeps` of callers.

I would also remove `gomega` and `ginkgo` to be 100% standalone. But didn't want to push too much, and `Godeps` does not embed them for caller packages.
