### PR TITLE
Makes stack function public

### DIFF
--- a/notice.go
+++ b/notice.go
@@ -28,7 +28,7 @@ func (n *Notice) String() string {
 }
 
 func NewNotice(e interface{}, req *http.Request, depth int) *Notice {
-	stack := stack(depth)
+	stack := Stack(depth)
 	notice := &Notice{
 		Errors: []Error{
 			{

--- a/util.go
+++ b/util.go
@@ -15,7 +15,7 @@ type StackFrame struct {
 	Func string `json:"function"`
 }
 
-func stack(depth int) []StackFrame {
+func Stack(depth int) []StackFrame {
 	stack := []StackFrame{}
 	for i := depth; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)


### PR DESCRIPTION
This function can be useful for users of the library in some circumstances
(e.g. if they want to log the stack trace not only to an Airbrake server but
also to another destination).