### PR TITLE
Extract stacktraces from errors of the pkg/errors package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ matrix:
 install:
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
+  - go get github.com/pkg/errors

--- a/notice.go
+++ b/notice.go
@@ -6,11 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var defaultContextOnce sync.Once
@@ -64,46 +61,6 @@ func (n *Notice) String() string {
 	}
 	e := n.Errors[0]
 	return fmt.Sprintf("Notice<%s: %s>", e.Type, e.Message)
-}
-
-// stackTraces returns the stackTrace of an error.
-// It is part of the errors package public interface.
-type stackTracer interface {
-	StackTrace() errors.StackTrace
-}
-
-// getStack returns the stacktrace associated with e. If e is an
-// error from the errors package its stacktrace is extracted, otherwise
-// the current stacktrace is collected end returned.
-func getStack(e interface{}, depth int) []StackFrame {
-	if err, ok := e.(stackTracer); ok {
-		return stackFromErrorWithStackTrace(err)
-	}
-
-	return stack(depth)
-}
-
-// stackFromErrorWithStackTrace extracts the stacktrace from e.
-func stackFromErrorWithStackTrace(e stackTracer) []StackFrame {
-	var frames []StackFrame
-	for _, f := range e.StackTrace() {
-		line, _ := strconv.ParseInt(fmt.Sprintf("%d", f), 10, 64)
-		sf := StackFrame{
-			Func: fmt.Sprintf("%n", f),
-			File: fmt.Sprintf("%s", f),
-			Line: int(line),
-		}
-		frames = append(frames, sf)
-	}
-	return frames
-}
-
-// getTypeName returns the type name of e.
-func getTypeName(e interface{}) string {
-	if err, ok := e.(error); ok {
-		e = errors.Cause(err)
-	}
-	return fmt.Sprintf("%T", e)
 }
 
 func NewNotice(e interface{}, req *http.Request, depth int) *Notice {

--- a/notice.go
+++ b/notice.go
@@ -83,39 +83,17 @@ func getStack(e interface{}, depth int) []StackFrame {
 	return stack(depth)
 }
 
-// parseFrame parses and errors.Frame and returns a non-nil StackFrame
-// if the parsing is successful.
-//
-// We need to parse a formatted output for the func. name/file name/line no.,
-// because Frame does not have public methods to access these values, only
-// the output is specified.
-func parseFrame(f *errors.Frame) *StackFrame {
-	// A stack frame can be formatted several ways:
-	//    %+s    func\nfile
-	//    %d    source line
-	buf := fmt.Sprintf("%+s\n%d", f, f)
-	parts := strings.Split(buf, "\n")
-	if len(parts) != 3 {
-		return nil
-	}
-
-	fn := strings.TrimSpace(parts[0])
-	file := strings.TrimSpace(parts[1])
-	line, err := strconv.ParseInt(parts[2], 10, 64)
-	if err != nil {
-		return nil
-	}
-	return &StackFrame{file, int(line), fn}
-}
-
 // stackFromErrorWithStackTrace extracts the stacktrace from e.
 func stackFromErrorWithStackTrace(e stackTracer) []StackFrame {
 	var frames []StackFrame
 	for _, f := range e.StackTrace() {
-		pf := parseFrame(&f)
-		if pf != nil {
-			frames = append(frames, *pf)
+		line, _ := strconv.ParseInt(fmt.Sprintf("%d", f), 10, 64)
+		sf := StackFrame{
+			Func: fmt.Sprintf("%n", f),
+			File: fmt.Sprintf("%s", f),
+			Line: int(line),
 		}
+		frames = append(frames, sf)
 	}
 	return frames
 }

--- a/notice.go
+++ b/notice.go
@@ -117,8 +117,6 @@ func stackFromErrorWithStackTrace(e stackTracer) []StackFrame {
 			frames = append(frames, *pf)
 		}
 	}
-	// Remove the frames of runtime.main and runtime.goexit
-	frames = frames[:len(frames)-2]
 	return frames
 }
 

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/airbrake/gobrake"
+	"github.com/pkg/errors"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,18 @@ var _ = Describe("Notifier", func() {
 		Expect(e.Type).To(Equal("string"))
 		Expect(e.Message).To(Equal("hello"))
 		Expect(e.Backtrace[1].File).To(Equal("[PROJECT_ROOT]/github.com/airbrake/gobrake/notifier_test.go"))
+	})
+
+	It("reports error and backtrace when error is created with pkg/errors", func() {
+		err := foo()
+		notify(err, nil)
+		e := sentNotice.Errors[0]
+
+		Expect(e.Type).To(Equal("*errors.fundamental"))
+		Expect(e.Message).To(Equal("Test"))
+		Expect(e.Backtrace[0].Func).To(Equal("github.com/airbrake/gobrake_test.bar"))
+		Expect(e.Backtrace[0].File).To(Equal("[PROJECT_ROOT]/github.com/airbrake/gobrake/notifier_test.go"))
+		Expect(e.Backtrace[1].Func).To(Equal("github.com/airbrake/gobrake_test.foo"))
 	})
 
 	It("reports context, env, session and params", func() {
@@ -178,3 +191,11 @@ var _ = Describe("rate limiting", func() {
 		Expect(requests).To(Equal(1))
 	})
 })
+
+func foo() error {
+	return bar()
+}
+
+func bar() error {
+	return errors.New("Test")
+}

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Notifier", func() {
 		e := sentNotice.Errors[0]
 		Expect(e.Type).To(Equal("string"))
 		Expect(e.Message).To(Equal("hello"))
-		Expect(e.Backtrace[0].File).To(Equal("[PROJECT_ROOT]/github.com/airbrake/gobrake/notifier_test.go"))
+		Expect(e.Backtrace[1].File).To(Equal("[PROJECT_ROOT]/github.com/airbrake/gobrake/notifier_test.go"))
 	})
 
 	It("reports context, env, session and params", func() {

--- a/util.go
+++ b/util.go
@@ -84,9 +84,13 @@ func stackFromErrorWithStackTrace(e stackTracer) []StackFrame {
 	var frames []StackFrame
 	for _, f := range e.StackTrace() {
 		line, _ := strconv.ParseInt(fmt.Sprintf("%d", f), 10, 64)
+		// We need to use %+s to get the relative path, see https://github.com/pkg/errors/issues/136.
+		funcAndPath := fmt.Sprintf("%+s", f)
+		parts := strings.Split(funcAndPath, "\n\t")
+
 		sf := StackFrame{
-			Func: fmt.Sprintf("%n", f),
-			File: fmt.Sprintf("%s", f),
+			Func: parts[0],
+			File: parts[1],
 			Line: int(line),
 		}
 		frames = append(frames, sf)


### PR DESCRIPTION

TODO:
* [x] write test
* [x] change `%s` to `%+s` (to use relative paths)

Errors created by pkg/errors capture the stacktrace of the place when
the errors are created. It makes debugging much more easier if
developers can see the real origin of the errors.

This commit introduces the special handling of errors from the
pkg/errors package.

Fixes #37 

Signed-off-by: Tibor Benke <ihrwein@gmail.com>