### PR TITLE
Sleep to give notice time to send

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ package main
 
 import (
     "errors"
+    "time"
 
     "github.com/airbrake/gobrake"
 )
@@ -35,6 +36,7 @@ func main() {
     defer airbrake.NotifyOnPanic()
 
     airbrake.Notify(errors.New("operation failed"), nil)
+    time.Sleep(50 * time.Millisecond)
 }
 ```
 


### PR DESCRIPTION
I couldn't get the notice to send to Airbrake without a short sleep.
Because the notice is sent asynchronously I think that the end of the
program was reached and exited before the notice could be sent.