### PR TITLE
Fix build error introduced by pkg/errors dependency

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -74,20 +74,10 @@ type stackTracer interface {
 // backtraceFromErrorWithStackTrace extracts the stacktrace from e.
 func backtraceFromErrorWithStackTrace(e stackTracer) (string, []StackFrame) {
 	stackTrace := e.StackTrace()
-	var pcs []uintptr
-	for _, f := range stackTrace {
-		pcs = append(pcs, uintptr(f))
-	}
 
-	ff := runtime.CallersFrames(pcs)
 	var firstPkg string
 	frames := make([]StackFrame, 0)
-	for {
-		f, ok := ff.Next()
-		if !ok {
-			break
-		}
-
+	for _, f := range stackTrace {
 		pkg, fn := splitPackageFuncName(f.Function)
 		if firstPkg == "" {
 			firstPkg = pkg


### PR DESCRIPTION
The breaking upstream change https://github.com/pkg/errors/commit/4f47277723cbe176eaef3bccb66a69de7a531157 caused builds to fail.

Patch to fix the type error and restore working builds.
