### PR TITLE
Back to airbrake

### DIFF
--- a/code_hunk.go
+++ b/code_hunk.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/airbrake/gobrake/internal/lrucache"
+	"github.com/jessicacglenn/gobrake/internal/lrucache"
 )
 
 var cache = lrucache.New(1000)

--- a/code_hunk.go
+++ b/code_hunk.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/jessicacglenn/gobrake/internal/lrucache"
+	"github.com/airbrake/gobrake/internal/lrucache"
 )
 
 var cache = lrucache.New(1000)


### PR DESCRIPTION
Hi team,

A couple of hours ago the master branch of pkg/errors changed Frame to be a uintptr instead of a struct. This caused a breaking change in airbrake for us. I've created a hacky work around that seems to be working for the moment, though it isn't neat, and it's probably not appropriate for your library.

However I thought if I sent it as a pull request it might make it easier for you to identify and fix your own way faster :-)