### PR TITLE
Revert "Fix build error introduced by pkg/errors dependency"

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -74,10 +74,20 @@ type stackTracer interface {
 // backtraceFromErrorWithStackTrace extracts the stacktrace from e.
 func backtraceFromErrorWithStackTrace(e stackTracer) (string, []StackFrame) {
 	stackTrace := e.StackTrace()
+	var pcs []uintptr
+	for _, f := range stackTrace {
+		pcs = append(pcs, uintptr(f))
+	}
 
+	ff := runtime.CallersFrames(pcs)
 	var firstPkg string
 	frames := make([]StackFrame, 0)
-	for _, f := range stackTrace {
+	for {
+		f, ok := ff.Next()
+		if !ok {
+			break
+		}
+
 		pkg, fn := splitPackageFuncName(f.Function)
 		if firstPkg == "" {
 			firstPkg = pkg


### PR DESCRIPTION
This reverts commit ebf2122579246386e87e21e68f3d4366edb8399b.

Closes https://github.com/airbrake/gobrake/pull/90