### PR TITLE
Log SendNotice errors

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -337,7 +337,11 @@ func (n *Notifier) NotifyOnPanic() {
 	if v := recover(); v != nil {
 		notice := n.Notice(v, nil, 2)
 		notice.Context["severity"] = "critical"
-		_, _ = n.SendNotice(notice)
+		_, err := n.SendNotice(notice)
+		if err != nil {
+			logger.Printf("Unable to send notice: %v", err)
+		}
+
 		panic(v)
 	}
 }


### PR DESCRIPTION
Currently any errors that occur when sending notices, via `NotifyOnPanic`, are being swallowed, making it difficult to debug why notices are not being sent to Airbrake. To help with this, we are suggesting to log the error.