### PR TITLE
travis: test against go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ env:
 go_import_path: github.com/airbrake/gobrake
 
 before_install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - tip
 
 matrix:


### PR DESCRIPTION
go1.13 was released on 2019/09/03:
https://golang.org/doc/devel/release.html#go1.13