### PR TITLE
notifier: log configuration errors and such

### DIFF
--- a/gobrake.go
+++ b/gobrake.go
@@ -13,3 +13,7 @@ var clock = clockwork.NewRealClock()
 func SetLogger(l *log.Logger) {
 	logger = l
 }
+
+func GetLogger() *log.Logger {
+	return logger
+}


### PR DESCRIPTION
Replaces #119 (Log SendNotice errors)

As of now gobrake's Notify call happily exits without telling anything no matter
if the error was sent or not. The user has no idea about the status. It can also
choke silently if you specify your project credentials incorrectly. This is not
very welcoming and it's also a potential debugging time sink (been there, done
that).

In order to be more vocal, we start logging these errors, so that now you can
have an idea why your notice is not delivered. On success we don't print
anything (same behaviour as before).