### PR TITLE
notifier_test: stop checking backtrace content

### DIFF
--- a/notifier_test.go
+++ b/notifier_test.go
@@ -108,12 +108,7 @@ var _ = Describe("Notifier", func() {
 		e := sentNotice.Errors[0]
 		Expect(e.Type).To(Equal("string"))
 		Expect(e.Message).To(Equal("hello"))
-
-		frame := e.Backtrace[0]
-		Expect(frame.File).To(ContainSubstring("gobrake/notifier_test.go"))
-		Expect(frame.Line).To(Equal(37))
-		Expect(frame.Func).To(ContainSubstring("glob..func"))
-		Expect(frame.Code[33]).To(Equal(""))
+		Expect(len(e.Backtrace)).NotTo(BeZero())
 	})
 
 	Context("DisableCodeHunks", func() {


### PR DESCRIPTION
Fixes #134 (Use fixtures for code hunk testing)

It turned out that we don't need fixtures to test that code. The expectations
can be simplified, so we just check that backtrace is not zero.

We already have fixtures that do what I had intended to
do (internal/testpkg1). We already cover code hunks in our tests.