### PR TITLE
Update filtering terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ opts := gobrake.NotifierOptions{
 }
 ```
 
-#### KeysBlacklist
+#### KeysBlocklist
 
 Specifies which keys in the payload (parameters, session data, environment data,
 etc) should be filtered. Before sending an error, filtered keys will be
@@ -178,13 +178,13 @@ secrets := []string{"mySecretKey"}
 // OR regexp keys
 // secrets := []*regexp.Regexp{regexp.MustCompile("mySecretKey")}
 
-blacklist := make([]interface{}, len(secrets))
+blocklist := make([]interface{}, len(secrets))
 for i, v := range secrets {
-	blacklist[i] = v
+	blocklist[i] = v
 }
 
 opts := gobrake.NotifierOptions{
-	KeysBlacklist: blacklist,
+	KeysBlocklist: blocklist,
 }
 ```
 

--- a/example_test.go
+++ b/example_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/airbrake/gobrake/v4"
 )
 
-func ExampleNewBlacklistKeysFilter() {
+func ExampleNewBlocklistKeysFilter() {
 	notifier := gobrake.NewNotifier(1, "key")
-	filter := gobrake.NewBlacklistKeysFilter("password", regexp.MustCompile("(?i)(user)"))
+	filter := gobrake.NewBlocklistKeysFilter("password", regexp.MustCompile("(?i)(user)"))
 	notifier.AddFilter(filter)
 
 	notice := &gobrake.Notice{

--- a/filter.go
+++ b/filter.go
@@ -21,7 +21,7 @@ func newNotifierFilter(notifier *Notifier) func(*Notice) *Notice {
 	}
 }
 
-func NewBlacklistKeysFilter(keys ...interface{}) func(*Notice) *Notice {
+func NewBlocklistKeysFilter(keys ...interface{}) func(*Notice) *Notice {
 	return func(notice *Notice) *Notice {
 		for _, key := range keys {
 			notice.Env = filterByKey(notice.Env, key)

--- a/notifier.go
+++ b/notifier.go
@@ -72,6 +72,9 @@ type NotifierOptions struct {
 	Revision string
 	// List of keys containing sensitive information that must be filtered out.
 	// Default is password, secret.
+	KeysBlocklist []interface{}
+	// Deprecated version of "KeysBlocklist". Still supported but will eventually
+	// be removed in a future release.
 	KeysBlacklist []interface{}
 	// Disables code hunks.
 	DisableCodeHunks bool
@@ -90,8 +93,12 @@ func (opt *NotifierOptions) init() {
 		opt.Revision = os.Getenv("SOURCE_VERSION")
 	}
 
-	if opt.KeysBlacklist == nil {
-		opt.KeysBlacklist = []interface{}{
+	if opt.KeysBlocklist == nil {
+		opt.KeysBlocklist = opt.KeysBlacklist
+	}
+
+	if opt.KeysBlocklist == nil {
+		opt.KeysBlocklist = []interface{}{
 			regexp.MustCompile("password"),
 			regexp.MustCompile("secret"),
 		}
@@ -190,8 +197,8 @@ func NewNotifierWithOptions(opt *NotifierOptions) *Notifier {
 	}
 	n.AddFilter(gopathFilter)
 
-	if len(opt.KeysBlacklist) > 0 {
-		n.AddFilter(NewBlacklistKeysFilter(opt.KeysBlacklist...))
+	if len(opt.KeysBlocklist) > 0 {
+		n.AddFilter(NewBlocklistKeysFilter(opt.KeysBlocklist...))
 	}
 
 	return n

--- a/notifier.go
+++ b/notifier.go
@@ -93,8 +93,9 @@ func (opt *NotifierOptions) init() {
 		opt.Revision = os.Getenv("SOURCE_VERSION")
 	}
 
-	if opt.KeysBlocklist == nil {
+	if len(opt.KeysBlacklist) > 0 {
 		opt.KeysBlocklist = opt.KeysBlacklist
+		logger.Printf("KeysBlacklist is a deprecated option. Use KeysBlocklist instead.")
 	}
 
 	if opt.KeysBlocklist == nil {

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -361,11 +361,18 @@ var _ = Describe("Deprecated filter keys option", func() {
 		}
 	})
 
-	JustBeforeEach(func() {
-		notifier = gobrake.NewNotifierWithOptions(opt)
-	})
-
 	It("applies filters", func() {
+		origLogger := gobrake.GetLogger()
+		defer func() {
+			gobrake.SetLogger(origLogger)
+		}()
+
+		buf := new(bytes.Buffer)
+		l := log.New(buf, "", 0)
+		gobrake.SetLogger(l)
+
+		notifier = gobrake.NewNotifierWithOptions(opt)
+
 		notice := &gobrake.Notice{
 			Errors: []gobrake.Error{{
 				Type:    "type1",
@@ -388,6 +395,9 @@ var _ = Describe("Deprecated filter keys option", func() {
 			"thingTwo": "[Filtered]",
 			"email":    "john@example.com",
 		}))
+		Expect(buf.String()).To(
+			ContainSubstring("KeysBlacklist is a deprecated option. Use KeysBlocklist instead."),
+		)
 	})
 })
 

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -74,8 +74,8 @@ var _ = Describe("Notifier", func() {
 		Expect(notifier.Close()).NotTo(HaveOccurred())
 	})
 
-	It("applies black list keys filter", func() {
-		filter := gobrake.NewBlacklistKeysFilter("password", regexp.MustCompile("(?i)(user)"))
+	It("applies block list keys filter", func() {
+		filter := gobrake.NewBlocklistKeysFilter("password", regexp.MustCompile("(?i)(user)"))
 		notifier.AddFilter(filter)
 
 		notice := &gobrake.Notice{
@@ -323,6 +323,71 @@ var _ = Describe("Notifier", func() {
 		Expect(buf.String()).To(
 			ContainSubstring("connect: connection refused"),
 		)
+	})
+})
+
+var _ = Describe("Deprecated filter keys option", func() {
+	var deprecatedKeysOption = []interface{}{
+		"thingOne",
+		"thingTwo",
+	}
+	var notifier *gobrake.Notifier
+	var sentNotice *gobrake.Notice
+
+	var opt *gobrake.NotifierOptions
+
+	BeforeEach(func() {
+		handler := func(w http.ResponseWriter, req *http.Request) {
+			b, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				panic(err)
+			}
+
+			sentNotice = new(gobrake.Notice)
+			err = json.Unmarshal(b, sentNotice)
+			Expect(err).To(BeNil())
+
+			w.WriteHeader(http.StatusCreated)
+			_, err = w.Write([]byte(`{"id":"123"}`))
+			Expect(err).To(BeNil())
+		}
+		server := httptest.NewServer(http.HandlerFunc(handler))
+
+		opt = &gobrake.NotifierOptions{
+			ProjectId:     1,
+			ProjectKey:    "key",
+			Host:          server.URL,
+			KeysBlacklist: deprecatedKeysOption,
+		}
+	})
+
+	JustBeforeEach(func() {
+		notifier = gobrake.NewNotifierWithOptions(opt)
+	})
+
+	It("applies filters", func() {
+		notice := &gobrake.Notice{
+			Errors: []gobrake.Error{{
+				Type:    "type1",
+				Message: "msg1",
+			}},
+			Env: map[string]interface{}{
+				"thingOne": "please filter this",
+				"thingTwo": "and this too",
+				"email":    "john@example.com",
+			},
+		}
+		notifier.Notify(notice, nil)
+		notifier.Flush()
+
+		e := sentNotice.Errors[0]
+		Expect(e.Type).To(Equal("type1"))
+		Expect(e.Message).To(Equal("msg1"))
+		Expect(sentNotice.Env).To(Equal(map[string]interface{}{
+			"thingOne": "[Filtered]",
+			"thingTwo": "[Filtered]",
+			"email":    "john@example.com",
+		}))
 	})
 })
 


### PR DESCRIPTION
Deprecate "KeysBlacklist" in favor of "KeysBlocklist"

https://github.com/airbrake/gobrake#keysblacklist

# Testing this

### Step 1

Clone this example Go repo I made for this purpose:
https://github.com/thompiler/go-example

```
git clone git@github.com:thompiler/go-example.git
```

Install this version of the notifier:

```
go get github.com/airbrake/gobrake/v4@update-filtering-term
```

### Step 2

Replace placeholders with project credentials:

https://github.com/thompiler/go-example/blob/master/main.go#L12-L13

```go
var airbrake = gobrake.NewNotifierWithOptions(&gobrake.NotifierOptions{
	ProjectId:     123,            // Replace with project ID
	ProjectKey:    "abcdef123456", // Replace with project API key
	KeysBlocklist: blocklist,      // Change to "KeysBlocklist" to test deprecated option
})
```

### Step 3

Run the project:

```
go run main.go
```

Note that the items "thingo" and "bingo" are replaced with `[Filtered]` in the Airbrake dashboard as expected when setting them as either `KeysBlacklist` (now deprecated) or the new `KeysBlocklist`.