### PR TITLE
notifier: add the DisableErrorNotifications option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Gobrake Changelog
 
 ### master
 
+* Added the `DisableErrorNotifications` option, which turns on/off notifications
+  sent via `airbrake.Notify()` calls
+  ([#147](https://github.com/airbrake/gobrake/pull/147))
+
 ### [v4.2.0][v4.2.0] (July 24, 2020)
 
 * Added support for APM for [Negroni](https://github.com/urfave/negroni)

--- a/notifier.go
+++ b/notifier.go
@@ -78,6 +78,8 @@ type NotifierOptions struct {
 	KeysBlacklist []interface{}
 	// Disables code hunks.
 	DisableCodeHunks bool
+	// Controls the error reporting feature.
+	DisableErrorNotifications bool
 
 	// http.Client that is used to interact with Airbrake API.
 	HTTPClient *http.Client
@@ -219,6 +221,14 @@ func (n *Notifier) AddFilter(fn func(*Notice) *Notice) {
 
 // Notify notifies Airbrake about the error.
 func (n *Notifier) Notify(e interface{}, req *http.Request) {
+	if n.opt.DisableErrorNotifications {
+		logger.Printf(
+			"error notifications are disabled, will not deliver notice=%q",
+			e,
+		)
+		return
+	}
+
 	notice := n.Notice(e, req, 1)
 	n.SendNoticeAsync(notice)
 }


### PR DESCRIPTION
This new option will likely not be used by our customers directly through the
gobrake config. However we need this option to support remote configuration, so
that its value will be decided/changed at runtime.

The option basically turns on/off `airbrake.Notify()` calls.