### PR TITLE
Add the DisableAPM option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Gobrake Changelog
 * Added the `DisableErrorNotifications` option, which turns on/off notifications
   sent via `airbrake.Notify()` calls
   ([#147](https://github.com/airbrake/gobrake/pull/147))
+* Added the `DisableAPM` option, which turns on/off notifications
+  sent via `airbrake.Routes.Notify()`, `airbrake.Queues.Notify()`,
+  `airbrake.Queries.Notify()` calls
+  ([#148](https://github.com/airbrake/gobrake/pull/148))
 
 ### [v4.2.0][v4.2.0] (July 24, 2020)
 

--- a/notifier.go
+++ b/notifier.go
@@ -80,6 +80,8 @@ type NotifierOptions struct {
 	DisableCodeHunks bool
 	// Controls the error reporting feature.
 	DisableErrorNotifications bool
+	// Controls the error reporting feature.
+	DisableAPM bool
 
 	// http.Client that is used to interact with Airbrake API.
 	HTTPClient *http.Client

--- a/queries.go
+++ b/queries.go
@@ -149,6 +149,13 @@ func (s *queryStats) send(m map[queryKey]*tdigestStat) error {
 }
 
 func (s *queryStats) Notify(c context.Context, q *QueryInfo) error {
+	if s.opt.DisableAPM {
+		return fmt.Errorf(
+			"APM is disabled, query is not sent: %s (%s:%d)",
+			q.Query, q.File, q.Line,
+		)
+	}
+
 	key := queryKey{
 		Method: q.Method,
 		Route:  q.Route,

--- a/queues.go
+++ b/queues.go
@@ -140,6 +140,12 @@ func (s *queueStats) send(m map[queueKey]*queueBreakdown) error {
 }
 
 func (s *queueStats) Notify(c context.Context, metric *QueueMetric) error {
+	if s.opt.DisableAPM {
+		return fmt.Errorf(
+			"APM is disabled, queue is not sent: %s", metric.Queue,
+		)
+	}
+
 	metric.finish()
 
 	total, err := metric.duration()

--- a/route_breakdown.go
+++ b/route_breakdown.go
@@ -134,6 +134,13 @@ func (s *routeBreakdowns) send(m map[routeBreakdownKey]*routeBreakdown) error {
 }
 
 func (s *routeBreakdowns) Notify(c context.Context, metric *RouteMetric) error {
+	if s.opt.DisableAPM {
+		return fmt.Errorf(
+			"APM is disabled, route breakdown is not sent: %s %s (status %d)",
+			metric.Method, metric.Route, metric.StatusCode,
+		)
+	}
+
 	if metric.StatusCode < 200 || (metric.StatusCode >= 300 && metric.StatusCode < 400) {
 		// ignore
 		return nil

--- a/routes.go
+++ b/routes.go
@@ -147,6 +147,13 @@ func (s *routeStats) send(m map[routeKey]*tdigestStat) error {
 
 // Notify adds new route stats.
 func (s *routeStats) Notify(c context.Context, req *RouteMetric) error {
+	if s.opt.DisableAPM {
+		return fmt.Errorf(
+			"APM is disabled, route is not sent: %s %s (status %d)",
+			req.Method, req.Route, req.StatusCode,
+		)
+	}
+
 	key := routeKey{
 		Method:     req.Method,
 		Route:      req.Route,


### PR DESCRIPTION
This new option will likely not be used by our customers directly through the
gobrake config. However we need this option to support remote configuration, so
that its value will be decided/changed at runtime.

The option basically turns on/off these calls:

* airbrake.Queues.Notify
* airbrake.Routes.Notify
* airbrake.Queries.Notify