### PR TITLE
Add the 'APMHost' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Gobrake Changelog
   sent via `airbrake.Routes.Notify()`, `airbrake.Queues.Notify()`,
   `airbrake.Queries.Notify()` calls
   ([#148](https://github.com/airbrake/gobrake/pull/148))
+* Added the `APMHost` option that sets the host to which APM data should be sent
+  to ([#150](https://github.com/airbrake/gobrake/pull/150))
 
 ### [v4.2.0][v4.2.0] (July 24, 2020)
 

--- a/notifier.go
+++ b/notifier.go
@@ -65,6 +65,8 @@ type NotifierOptions struct {
 	ProjectKey string
 	// Airbrake host name. Default is https://airbrake.io.
 	Host string
+	// Airbrake host name for sending APM data.
+	APMHost string
 
 	// Environment such as production or development.
 	Environment string
@@ -90,6 +92,10 @@ type NotifierOptions struct {
 func (opt *NotifierOptions) init() {
 	if opt.Host == "" {
 		opt.Host = "https://api.airbrake.io"
+	}
+
+	if opt.APMHost == "" {
+		opt.APMHost = opt.Host
 	}
 
 	if opt.Revision == "" {

--- a/queries.go
+++ b/queries.go
@@ -51,7 +51,7 @@ func newQueryStats(opt *NotifierOptions) *queryStats {
 	return &queryStats{
 		opt: opt,
 		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/queries-stats",
-			opt.Host, opt.ProjectId),
+			opt.APMHost, opt.ProjectId),
 	}
 }
 

--- a/queues.go
+++ b/queues.go
@@ -46,7 +46,7 @@ func newQueueStats(opt *NotifierOptions) *queueStats {
 	return &queueStats{
 		opt: opt,
 		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/queues-stats",
-			opt.Host, opt.ProjectId),
+			opt.APMHost, opt.ProjectId),
 	}
 }
 

--- a/route_breakdown.go
+++ b/route_breakdown.go
@@ -37,7 +37,7 @@ func newRouteBreakdowns(opt *NotifierOptions) *routeBreakdowns {
 	return &routeBreakdowns{
 		opt: opt,
 		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/routes-breakdowns",
-			opt.Host, opt.ProjectId),
+			opt.APMHost, opt.ProjectId),
 	}
 }
 

--- a/routes.go
+++ b/routes.go
@@ -43,7 +43,7 @@ func newRouteStats(opt *NotifierOptions) *routeStats {
 	return &routeStats{
 		opt: opt,
 		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/routes-stats",
-			opt.Host, opt.ProjectId),
+			opt.APMHost, opt.ProjectId),
 	}
 }
 


### PR DESCRIPTION
This option is similar to the `Host` option but it allows configuring host to
which APM data should be sent to.

Configuring this manually probably doesn't make much sense but it will be used
in the upcoming remote configuration work.