### PR TITLE
Add ability to change reroute traffic at runtime

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -177,9 +177,7 @@ func (rs *routes) Notify(c context.Context, metric *RouteMetric) error {
 }
 
 type Notifier struct {
-	opt             *NotifierOptions
-	createNoticeURL string
-
+	opt     *NotifierOptions
 	filters []filter
 
 	inFlight int32 // atomic
@@ -198,10 +196,7 @@ func NewNotifierWithOptions(opt *NotifierOptions) *Notifier {
 	opt.init()
 
 	n := &Notifier{
-		opt: opt,
-		createNoticeURL: fmt.Sprintf("%s/api/v3/projects/%d/notices",
-			opt.Host, opt.ProjectId),
-
+		opt:   opt,
 		limit: make(chan struct{}, 2*runtime.NumCPU()),
 
 		Routes:  newRoutes(opt),
@@ -295,7 +290,12 @@ func (n *Notifier) sendNotice(notice *Notice) (string, error) {
 		return "", errNoticeTooBig
 	}
 
-	req, err := http.NewRequest("POST", n.createNoticeURL, buf)
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("%s/api/v3/projects/%d/notices",
+			n.opt.Host, n.opt.ProjectId),
+		buf,
+	)
 	if err != nil {
 		return "", err
 	}

--- a/queries.go
+++ b/queries.go
@@ -37,9 +37,7 @@ type queryKeyStat struct {
 }
 
 type queryStats struct {
-	opt    *NotifierOptions
-	apiURL string
-
+	opt        *NotifierOptions
 	flushTimer *time.Timer
 	addWG      *sync.WaitGroup
 
@@ -50,8 +48,6 @@ type queryStats struct {
 func newQueryStats(opt *NotifierOptions) *queryStats {
 	return &queryStats{
 		opt: opt,
-		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/queries-stats",
-			opt.APMHost, opt.ProjectId),
 	}
 }
 
@@ -113,7 +109,12 @@ func (s *queryStats) send(m map[queryKey]*tdigestStat) error {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", s.apiURL, buf)
+	req, err := http.NewRequest(
+		"PUT",
+		fmt.Sprintf("%s/api/v5/projects/%d/queries-stats",
+			s.opt.APMHost, s.opt.ProjectId),
+		buf,
+	)
 	if err != nil {
 		return err
 	}

--- a/queues.go
+++ b/queues.go
@@ -32,9 +32,7 @@ func (b *queueBreakdown) Add(total time.Duration, groups map[string]time.Duratio
 }
 
 type queueStats struct {
-	opt    *NotifierOptions
-	apiURL string
-
+	opt        *NotifierOptions
 	flushTimer *time.Timer
 	addWG      *sync.WaitGroup
 
@@ -45,8 +43,6 @@ type queueStats struct {
 func newQueueStats(opt *NotifierOptions) *queueStats {
 	return &queueStats{
 		opt: opt,
-		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/queues-stats",
-			opt.APMHost, opt.ProjectId),
 	}
 }
 
@@ -104,7 +100,12 @@ func (s *queueStats) send(m map[queueKey]*queueBreakdown) error {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", s.apiURL, buf)
+	req, err := http.NewRequest(
+		"PUT",
+		fmt.Sprintf("%s/api/v5/projects/%d/queues-stats",
+			s.opt.APMHost, s.opt.ProjectId),
+		buf,
+	)
 	if err != nil {
 		return err
 	}

--- a/route_breakdown.go
+++ b/route_breakdown.go
@@ -23,9 +23,7 @@ type routeBreakdown struct {
 }
 
 type routeBreakdowns struct {
-	opt    *NotifierOptions
-	apiURL string
-
+	opt        *NotifierOptions
 	flushTimer *time.Timer
 	addWG      *sync.WaitGroup
 
@@ -36,8 +34,6 @@ type routeBreakdowns struct {
 func newRouteBreakdowns(opt *NotifierOptions) *routeBreakdowns {
 	return &routeBreakdowns{
 		opt: opt,
-		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/routes-breakdowns",
-			opt.APMHost, opt.ProjectId),
 	}
 }
 
@@ -100,7 +96,12 @@ func (s *routeBreakdowns) send(m map[routeBreakdownKey]*routeBreakdown) error {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", s.apiURL, buf)
+	req, err := http.NewRequest(
+		"PUT",
+		fmt.Sprintf("%s/api/v5/projects/%d/routes-breakdowns",
+			s.opt.APMHost, s.opt.ProjectId),
+		buf,
+	)
 	if err != nil {
 		return err
 	}

--- a/routes.go
+++ b/routes.go
@@ -29,9 +29,7 @@ type routeFilter func(*RouteMetric) *RouteMetric
 // routeStats aggregates information about requests and periodically sends
 // collected data to Airbrake.
 type routeStats struct {
-	opt    *NotifierOptions
-	apiURL string
-
+	opt        *NotifierOptions
 	flushTimer *time.Timer
 	addWG      *sync.WaitGroup
 
@@ -42,8 +40,6 @@ type routeStats struct {
 func newRouteStats(opt *NotifierOptions) *routeStats {
 	return &routeStats{
 		opt: opt,
-		apiURL: fmt.Sprintf("%s/api/v5/projects/%d/routes-stats",
-			opt.APMHost, opt.ProjectId),
 	}
 }
 
@@ -110,7 +106,12 @@ func (s *routeStats) send(m map[routeKey]*tdigestStat) error {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", s.apiURL, buf)
+	req, err := http.NewRequest(
+		"PUT",
+		fmt.Sprintf("%s/api/v5/projects/%d/routes-stats",
+			s.opt.APMHost, s.opt.ProjectId),
+		buf,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is going to be used mostly by the remote configuration features. At the
moment you can configure `Host` and `APMHost` options to route your traffic,
however these values are static (cannot be changed at runtime).

With this commit we can redefine these two options and runtime and the traffic
will be redirected to the new location.