### PR TITLE
remote_config: copy notifier opts properly

### DIFF
--- a/beego/filter.go
+++ b/beego/filter.go
@@ -35,7 +35,7 @@ func afterExecFunc(notifier *gobrake.Notifier) func(c *context.Context) {
 			metric.StatusCode = 200
 		}
 
-		_ = notifier.Routes.Notify(goctx.TODO(), metric)
+		_ := notifier.Routes.Notify(goctx.TODO(), metric)
 	}
 }
 

--- a/notifier.go
+++ b/notifier.go
@@ -136,6 +136,25 @@ func (opt *NotifierOptions) init() {
 	}
 }
 
+// Makes a shallow copy (without copying slices or nested structs; because we
+// don't need it so far).
+func (opt *NotifierOptions) Copy() *NotifierOptions {
+	return &NotifierOptions{
+		ProjectId:                 opt.ProjectId,
+		ProjectKey:                opt.ProjectKey,
+		Host:                      opt.Host,
+		APMHost:                   opt.APMHost,
+		RemoteConfigHost:          opt.RemoteConfigHost,
+		Environment:               opt.Environment,
+		Revision:                  opt.Revision,
+		KeysBlocklist:             opt.KeysBlocklist,
+		DisableCodeHunks:          opt.DisableCodeHunks,
+		DisableErrorNotifications: opt.DisableErrorNotifications,
+		DisableAPM:                opt.DisableAPM,
+		HTTPClient:                opt.HTTPClient,
+	}
+}
+
 type routes struct {
 	filters []routeFilter
 

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -706,3 +706,78 @@ var _ = Describe("Notifier request filter", func() {
 		})
 	})
 })
+
+var _ = Describe("(*NotifierOptions).Copy()", func() {
+	var opt = &gobrake.NotifierOptions{
+		ProjectId:                 1,
+		ProjectKey:                "2",
+		Host:                      "error host",
+		APMHost:                   "apm host",
+		RemoteConfigHost:          "cfg host",
+		Environment:               "env",
+		Revision:                  "rev",
+		DisableCodeHunks:          true,
+		DisableErrorNotifications: true,
+		DisableAPM:                true,
+	}
+
+	It("copies ProjectId", func() {
+		copy := opt.Copy()
+		copy.ProjectId = 99
+		Expect(opt.ProjectId).To(Equal(int64(1)))
+	})
+
+	It("copies ProjectKey", func() {
+		copy := opt.Copy()
+		copy.ProjectKey = "99"
+		Expect(opt.ProjectKey).To(Equal("2"))
+	})
+
+	It("copies Host", func() {
+		copy := opt.Copy()
+		copy.Host = "aaa"
+		Expect(opt.Host).To(Equal("error host"))
+	})
+
+	It("copies APMHost", func() {
+		copy := opt.Copy()
+		copy.APMHost = "aaa"
+		Expect(opt.APMHost).To(Equal("apm host"))
+	})
+
+	It("copies RemoteConfigHost", func() {
+		copy := opt.Copy()
+		copy.RemoteConfigHost = "aaa"
+		Expect(opt.RemoteConfigHost).To(Equal("cfg host"))
+	})
+
+	It("copies Environment", func() {
+		copy := opt.Copy()
+		copy.Environment = "aaa"
+		Expect(opt.Environment).To(Equal("env"))
+	})
+
+	It("copies Revision", func() {
+		copy := opt.Copy()
+		copy.Revision = "aaa"
+		Expect(opt.Revision).To(Equal("rev"))
+	})
+
+	It("copies DisableCodeHunks", func() {
+		copy := opt.Copy()
+		copy.DisableCodeHunks = false
+		Expect(opt.DisableCodeHunks).To(BeTrue())
+	})
+
+	It("copies DisableErrorNotifications", func() {
+		copy := opt.Copy()
+		copy.DisableErrorNotifications = false
+		Expect(opt.DisableErrorNotifications).To(BeTrue())
+	})
+
+	It("copies DisableAPM", func() {
+		copy := opt.Copy()
+		copy.DisableAPM = false
+		Expect(opt.DisableAPM).To(BeTrue())
+	})
+})

--- a/remote_config.go
+++ b/remote_config.go
@@ -57,11 +57,9 @@ type RemoteSettings struct {
 }
 
 func newRemoteConfig(opt *NotifierOptions) *remoteConfig {
-	optCopy := opt
-
 	return &remoteConfig{
 		opt:     opt,
-		origOpt: optCopy,
+		origOpt: opt.Copy(),
 
 		JSON: &RemoteConfigJSON{},
 	}


### PR DESCRIPTION
The old way wasn't copying the struct properly. When we modified the copy, the
original struct was also modified. The new way of copying is manual but it
works!