### PR TITLE
remote_config: improve error message when config is not fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Gobrake Changelog
 
 ### master
 
+* Remote config: improved error message when config cannot be requested from S3
+  ([#178](https://github.com/airbrake/gobrake/pull/178))
+
 ### [v5.0.1][v5.0.1] (September 1, 2020)
 
 * Fixed bug where `gobrake: span="http.client" is already finished gets printed`

--- a/remote_config.go
+++ b/remote_config.go
@@ -110,9 +110,12 @@ func (rc *remoteConfig) Poll() {
 }
 
 func (rc *remoteConfig) tick() error {
-	body, err := rc.fetchConfig(rc.ConfigRoute(rc.opt.RemoteConfigHost))
+	route := rc.ConfigRoute(rc.opt.RemoteConfigHost)
+	body, err := rc.fetchConfig(route)
 	if err != nil {
-		return fmt.Errorf("fetchConfig failed: %s", err)
+		return fmt.Errorf(
+			"fetchConfig failed for %s. Reason: %s", route, err,
+		)
 	}
 	if err = json.Unmarshal(body, rc.JSON); err != nil {
 		return fmt.Errorf("parseConfig failed: %s", err)

--- a/remote_config_test.go
+++ b/remote_config_test.go
@@ -125,9 +125,8 @@ var _ = Describe("newRemoteConfig", func() {
 				rc.Poll()
 				rc.StopPolling()
 
-				Expect(logBuf.String()).To(
-					ContainSubstring("fetchConfig failed: not found"),
-				)
+				Expect(logBuf.String()).To(ContainSubstring("fetchConfig failed"))
+				Expect(logBuf.String()).To(ContainSubstring("not found"))
 			})
 		})
 
@@ -147,9 +146,8 @@ var _ = Describe("newRemoteConfig", func() {
 				rc.Poll()
 				rc.StopPolling()
 
-				Expect(logBuf.String()).To(
-					ContainSubstring("fetchConfig failed: forbidden"),
-				)
+				Expect(logBuf.String()).To(ContainSubstring("fetchConfig failed"))
+				Expect(logBuf.String()).To(ContainSubstring("forbidden"))
 			})
 		})
 


### PR DESCRIPTION
Our current message provides a reason why the config is not fetched but it
doesn't give any clue what URL is being requested. By printing the requested URL
it's easier to debug certain scenarios.