### PR TITLE
remote_config: delete the code for config dumping/loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Gobrake Changelog
 
 ### master
 
+* Deleted support for dumping/loading the remote config
+  ([#186](https://github.com/airbrake/gobrake/pull/186))
+
 ### [v5.0.2][v5.0.2] (September 8, 2020)
 
 * Remote config: improved error message when config cannot be requested from S3

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -37,18 +37,6 @@ func newConfigServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(handler))
 }
 
-func cleanupConfig() {
-	configPath := "config.json"
-
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return
-	}
-
-	if err := os.Remove(configPath); err != nil {
-		log.Fatal(err)
-	}
-}
-
 var _ = Describe("Notifier", func() {
 	var notifier *gobrake.Notifier
 	var sentNotice *gobrake.Notice

--- a/race_test.go
+++ b/race_test.go
@@ -32,10 +32,6 @@ var _ = Describe("Notifier", func() {
 		})
 	})
 
-	AfterEach(func() {
-		cleanupConfig()
-	})
-
 	It("is race free", func() {
 		var wg sync.WaitGroup
 		for i := 0; i < 100; i++ {

--- a/remote_config_test.go
+++ b/remote_config_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"runtime"
 	"time"
 
@@ -13,27 +12,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func cleanupConfig() {
-	configPath := "config.json"
-
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return
-	}
-
-	if err := os.Remove(configPath); err != nil {
-		log.Fatal(err)
-	}
-}
-
 var _ = Describe("newRemoteConfig", func() {
 	var rc *remoteConfig
 	var opt *NotifierOptions
 	var origLogger *log.Logger
 	var logBuf *bytes.Buffer
-
-	AfterEach(func() {
-		cleanupConfig()
-	})
 
 	Describe("Poll", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
 Fixes #185 (dumpConfig failed: no such file or directory)

Some of our users complain that gobrake tries to dump the remote config that we
pull from S3 to the GOPATH directory. The OS user that is running the code may
not have write access to that directory and therefore writing the remote config
will fail. This is especially evident when gobrake runs inside a
container. Persistency in a container makes no sense.

There's no good universal location to keep persistent remote config, so it's
easier just to delete the config.