### PR TITLE
notifier: add the DisableRemoteConfig option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Gobrake Changelog
 
 ### master
 
+* Added the `DisableRemoteConfig` option. This option configures the remote
+  configuration feature ([#194](https://github.com/airbrake/gobrake/pull/194))
+
 ### [v5.0.3][v5.0.3] (November 17, 2020)
 
 * Deleted support for dumping/loading the remote config

--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ opts := gobrake.NotifierOptions{
 }
 ```
 
+#### DisableRemoteConfig
+
+Configures the remote configuration feature. At regular intervals the notifier
+will be making `GET` requests to Airbrake servers and fetching a JSON document
+containing configuration settings of the notifier. The notifier will apply these
+new settings at runtime. By default, this option is set to `false` (the feature
+is enabled).
+
+Note: it is not recommended to disable this feature. It might negatively impact
+how your notifier works. Please use this option with caution.
+
 ## API
 
 For complete API description please follow documentation on [pkg.go.dev

--- a/notifier.go
+++ b/notifier.go
@@ -74,6 +74,9 @@ type NotifierOptions struct {
 	// The host name where the remote config is located.
 	RemoteConfigHost string
 
+	// Controles the remote config feature.
+	DisableRemoteConfig bool
+
 	// Environment such as production or development.
 	Environment string
 
@@ -237,7 +240,9 @@ func NewNotifierWithOptions(opt *NotifierOptions) *Notifier {
 		n.AddFilter(NewBlocklistKeysFilter(opt.KeysBlocklist...))
 	}
 
-	n.remoteConfig.Poll()
+	if !opt.DisableRemoteConfig {
+		n.remoteConfig.Poll()
+	}
 
 	return n
 }

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -205,6 +205,34 @@ var _ = Describe("Notifier", func() {
 		})
 	})
 
+	Context("DisableRemoteConfig", func() {
+		var notifierConfigReq *http.Request
+
+		BeforeEach(func() {
+			opt.DisableRemoteConfig = true
+
+			handler := func(w http.ResponseWriter, req *http.Request) {
+				notifierConfigReq = req
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(`{}`))
+				Expect(err).To(BeNil())
+			}
+			configServer := httptest.NewServer(http.HandlerFunc(handler))
+
+			opt.RemoteConfigHost = configServer.URL
+			notifierConfigReq = nil
+		})
+
+		AfterEach(func() {
+			opt.DisableRemoteConfig = false
+		})
+
+		It("does not poll remote configuration", func() {
+			notifier.Close()
+			Expect(notifierConfigReq).To(BeNil())
+		})
+	})
+
 	It("reports error and backtrace when error is created with pkg/errors", func() {
 		err := testpkg1.Foo()
 		notify(err, nil)


### PR DESCRIPTION
This new option configures the remote configuration feature.

Note: it is not recommended to disable this feature. It might negatively impact
how your notifier works. Please use this option with caution.