### PR TITLE
Beego Status fix

### DIFF
--- a/beego/filter.go
+++ b/beego/filter.go
@@ -29,7 +29,11 @@ func New(notifier *gobrake.Notifier) web.FilterChain {
 			}
 			_, metric := gobrake.NewRouteMetric(goctx.TODO(), ctx.Input.Method(), routerPattern)
 			next(ctx)
-			metric.StatusCode = ctx.ResponseWriter.Status
+			statusCode := ctx.ResponseWriter.Status
+			if statusCode == 0 {
+				statusCode = 200
+			}
+			metric.StatusCode = statusCode
 			_ = notifier.Routes.Notify(goctx.TODO(), metric)
 
 		}


### PR DESCRIPTION
When the `response status` is ok, the beego application sets it to `0`. To fix that when we send the notice to airbrake, we overwrite the status to StatusOK i.e. `200`