### PR TITLE
Update apex/log handler for automatic linking of errors to routes

### DIFF
--- a/apexlog/apexlog.go
+++ b/apexlog/apexlog.go
@@ -30,8 +30,15 @@ func (h *Handler) notifyAirbrake(level log.Level, msg string, params log.Fields)
 	}
 
 	notice := gobrake.NewNotice(msg, nil, 0)
+	parameters := asParams(params)
+	for key, parameter := range parameters {
+		if key == "httpMethod" || key == "route" {
+			notice.Context[key] = parameter
+			delete(parameters, key)
+		}
+	}
 	notice.Context["severity"] = level.String()
-	notice.Params = asParams(params)
+	notice.Params = parameters
 
 	h.Gobrake.Notify(notice, nil)
 }


### PR DESCRIPTION
Update apex/log handler to check for a couple special fields i.e. `route` and `httpMethod`, and if present, move them from `Notice.Params` to `Notice.Context` for automatic linking of errors to routes.