### PR TITLE
Show proper error message which API gives 429 response

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -318,7 +318,12 @@ func (n *Notifier) sendNotice(notice *Notice) (string, error) {
 		if err == nil {
 			atomic.StoreUint32(&n.rateLimitReset, uint32(time.Now().Unix()+delay))
 		}
-		return "", errIPRateLimited
+		var sendResp sendResponse
+		err = json.NewDecoder(buf).Decode(&sendResp)
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New(sendResp.Message)
 	case httpEnhanceYourCalm:
 		return "", errAccountRateLimited
 	case http.StatusRequestEntityTooLarge:

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -475,7 +475,7 @@ var _ = Describe("rate limiting", func() {
 		notice := notifier.Notice("hello", nil, 3)
 		for i := 0; i < 3; i++ {
 			_, err := notifier.SendNotice(notice)
-			Expect(err).To(MatchError("gobrake: IP is rate limited"))
+			Expect(err).NotTo(BeNil())
 		}
 		Expect(requests).To(Equal(1))
 	})

--- a/queries.go
+++ b/queries.go
@@ -142,9 +142,7 @@ func (s *queryStats) send(m map[queryKey]*tdigestStat) error {
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
 		return errUnauthorized
-	case http.StatusTooManyRequests:
-		return errIPRateLimited
-	case http.StatusBadRequest:
+	case http.StatusBadRequest, http.StatusTooManyRequests:
 		var sendResp sendResponse
 		err = json.NewDecoder(buf).Decode(&sendResp)
 		if err != nil {

--- a/queues.go
+++ b/queues.go
@@ -133,9 +133,7 @@ func (s *queueStats) send(m map[queueKey]*queueBreakdown) error {
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
 		return errUnauthorized
-	case http.StatusTooManyRequests:
-		return errIPRateLimited
-	case http.StatusBadRequest:
+	case http.StatusBadRequest, http.StatusTooManyRequests:
 		var sendResp sendResponse
 		err = json.NewDecoder(buf).Decode(&sendResp)
 		if err != nil {

--- a/route_breakdown.go
+++ b/route_breakdown.go
@@ -129,9 +129,7 @@ func (s *routeBreakdowns) send(m map[routeBreakdownKey]*routeBreakdown) error {
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
 		return errUnauthorized
-	case http.StatusTooManyRequests:
-		return errIPRateLimited
-	case http.StatusBadRequest:
+	case http.StatusBadRequest, http.StatusTooManyRequests:
 		var sendResp sendResponse
 		err = json.NewDecoder(buf).Decode(&sendResp)
 		if err != nil {

--- a/route_stat.go
+++ b/route_stat.go
@@ -137,9 +137,7 @@ func (s *routeStats) send(m map[routeKey]*tdigestStat) error {
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
 		return errUnauthorized
-	case http.StatusTooManyRequests:
-		return errIPRateLimited
-	case http.StatusBadRequest:
+	case http.StatusBadRequest, http.StatusTooManyRequests:
 		var sendResp sendResponse
 		err = json.NewDecoder(buf).Decode(&sendResp)
 		if err != nil {


### PR DESCRIPTION
For the time being, if a response receives a 429 error, it will check to see if X-RateLimit-Delay is present or not in headers. If it is not, it will send the message 'X-RateLimit-Delay header is missing', otherwise it will compute the rate limit and send the static message 'IP is rate limited'.

Need to change
--------------

Replace the static message that says 'IP is rate limited' with the message that is received from the response body.