### PR TITLE
.github/workflows/test: stop testing against go1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.18, 1.19]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Latest GolangCI Lint doesn't support go1.17 anymore but we still do. Locking to
an older GolangCI Lint doesn't work properly, so it's easier to stop testing
against go1.17.