### PR TITLE
NotifyOnPanic panics when n.SendNotice returns an error

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -390,7 +390,7 @@ func (n *Notifier) NotifyOnPanic() {
 				"SendNotice failed reporting notice=%q: %s",
 				notice, err,
 			)
-			return
+			panic(v)
 		}
 
 		panic(v)


### PR DESCRIPTION
A panic should always result in a non-zero exit code. This change ensures that a panic will still occur, even in the error case where the airbrake notification failed for some reason.